### PR TITLE
Rename the Null class to enable php7 support

### DIFF
--- a/src/DataTypes/JsonObject.php
+++ b/src/DataTypes/JsonObject.php
@@ -57,7 +57,7 @@ abstract class JsonObject extends MagicArray
     protected function convertValue($value, $offset)
     {
         if (is_null($value)) {
-            return new Null();
+            return new NullDataType();
         }
         $convertedOffset = $this->convertOffset($offset);
         $dataClass = $this->classes[$convertedOffset];

--- a/src/DataTypes/NullDataType.php
+++ b/src/DataTypes/NullDataType.php
@@ -8,7 +8,7 @@
 
 namespace DotMailer\Api\DataTypes;
 
-class Null implements IDataType
+class NullDataType implements IDataType
 {
 
     public function toJson()
@@ -25,5 +25,4 @@ class Null implements IDataType
     {
         return $this->toJson();
     }
-
 }


### PR DESCRIPTION
Fixes https://github.com/romanpitak/dotMailer-API-v2-PHP-client/issues/22 upstream issue.

Duplicate's code in https://github.com/romanpitak/dotMailer-API-v2-PHP-client/pull/25#issuecomment-300580066